### PR TITLE
Reduce the Flatpak size

### DIFF
--- a/org.kde.okteta.json
+++ b/org.kde.okteta.json
@@ -14,7 +14,11 @@
     ],
     "cleanup": [
         "/include",
-        "/lib/pkgconfig"
+        "/lib/cmake",
+        "/lib/pkgconfig",
+        "/mkspecs",
+        "/share/doc",
+        "/share/man"
     ],
     "modules": [
         {


### PR DESCRIPTION
The installed size reduced from 7.8 MB to 6.9 MB.

KDE apps usually open an external website for help documentation.

Therefore, it's not required to keep the /share/doc folder.